### PR TITLE
fix: add typing-extensions dependency for Python 3.10 support

### DIFF
--- a/packages/ttkbootstrap-icons/pyproject.toml
+++ b/packages/ttkbootstrap-icons/pyproject.toml
@@ -30,7 +30,10 @@ classifiers = [
     "Topic :: Software Development :: User Interfaces",
     "Operating System :: OS Independent"
 ]
-dependencies = ["pillow>=9.1.0"]
+dependencies = [
+    "pillow>=9.1.0",
+    "typing-extensions>=4.7.1"
+]
 
 [project.scripts]
 ttkbootstrap-icons = "ttkbootstrap_icons.browser:main"


### PR DESCRIPTION
Resolves #57 by adding typing-extensions>=4.7.1 as a project dependency. This provides NotRequired and TypedDict for Python 3.10 environments where these types are not yet available in the standard typing module.